### PR TITLE
Keep the fixed params when refitting the tuned model

### DIFF
--- a/src/neuralk_foundry_ce/models/base.py
+++ b/src/neuralk_foundry_ce/models/base.py
@@ -53,6 +53,16 @@ class BaseModel(Step):
         Field('n_hyperopt_trials', 'Number of trials attempted for hyperparameter optimization', default=100),
     ]
 
+    def get_fixed_params(self, inputs):
+        """Parameters held constant across hyperparameter trials.
+
+        Both `_execute` and `hyperopt` call this unconditionally, but only the classifiers
+        defined it, so every regressor raised AttributeError before a model was ever built.
+        An empty default keeps the contract total; subclasses override it.
+        """
+        return {}
+
+
     def _correct_predicted_proba(self, y_score):
         if len(y_score.shape) == 1:
             # assume binary classification and proba for class 1.
@@ -196,7 +206,10 @@ class BaseModel(Step):
                 n_ensemble=n_ensemble
             )
 
-            best_params = best_trial.params
+            # Optuna records only what it sampled, so refitting from best_trial.params alone
+            # drops everything get_fixed_params supplies. Merge them the same way the trials
+            # did, with the fixed values taking precedence.
+            best_params = best_trial.params | self.get_fixed_params(inputs)
             self.init_model(best_params)
 
             # Take care of ensembles first

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -62,3 +62,61 @@ def test_mlp_unknown_category_handling():
     assert len(y_pred) == len(df_test)
 
     print("Test passed: unknown category logic behaves as expected.")
+
+def test_hyperopt_refit_keeps_the_fixed_params():
+    # After tuning, base.py refits the model from the best trial's sampled parameters.
+    # get_fixed_params carries the objective, the metric and the verbosity, none of which
+    # Optuna records, so a refit built from best_trial.params alone trains a differently
+    # configured model than every trial that was scored.
+    from neuralk_foundry_ce.config import global_config
+    from neuralk_foundry_ce.models.classifier import LightGBMClassifier
+    from neuralk_foundry_ce.utils.splitting import Split
+
+    seen = []
+
+    class Recorder(LightGBMClassifier):
+        def init_model(self, config):
+            seen.append(dict(config))
+            super().init_model(config)
+
+    rng = np.random.RandomState(0)
+    n = 300
+    X = rng.randn(n, 8)
+    y = (X[:, 0] + X[:, 1] - X[:, 2] + rng.randn(n) * 0.3 > 0).astype(int)
+    split = np.empty(n, dtype=object)
+    split[:] = Split.TRAIN
+    split[int(n * 0.6):int(n * 0.8)] = Split.VAL
+    split[int(n * 0.8):] = Split.TEST
+
+    global_config.set('n_hyperopt_trials', 2)
+    global_config.set('ensemble', False)
+    model = Recorder()
+    model.n_ensemble = None
+    model.logged_metrics = {}
+    model._returned_outputs = {}
+    model._execute({'X': X, 'y': y, 'splits': [split], 'metric_to_optimize': 'roc_auc'})
+
+    assert len(seen) >= 2, 'expected at least one trial and one refit'
+    refit = seen[-1]
+    for key in ('objective', 'metric', 'verbose'):
+        assert key in refit, (
+            f'the post-tuning refit dropped {key!r} from get_fixed_params; it trains a '
+            f'differently configured model than the trials that were scored'
+        )
+
+
+def test_every_model_exposes_get_fixed_params():
+    # _execute and hyperopt both call get_fixed_params unconditionally, so a model without
+    # one raises AttributeError before any model is built. Only the classifiers defined it.
+    from neuralk_foundry_ce.models.base import BaseModel
+    from neuralk_foundry_ce.models.regressor.lightgbm import LightGBMRegressor
+    from neuralk_foundry_ce.models.regressor.xgboost import XGBoostRegressor
+    from neuralk_foundry_ce.models.regressor.catboost import CatBoostRegressor
+
+    assert hasattr(BaseModel, 'get_fixed_params'), (
+        'the contract is called unconditionally, so it belongs on the base class'
+    )
+    for cls in (LightGBMRegressor, XGBoostRegressor, CatBoostRegressor):
+        assert isinstance(cls().get_fixed_params({}), dict), (
+            f'{cls.__name__} cannot supply fixed params, so hyperopt raises before fitting'
+        )


### PR DESCRIPTION
---

`_execute` refits the tuned model from `best_trial.params` alone at `models/base.py:199`.
Optuna records only what it sampled, so everything `get_fixed_params` supplies is missing from
that call even though `hyperopt.py:314` merged it into every scored trial. This merges it back
the same way, fixed values last.

It also adds an empty `get_fixed_params` on `BaseModel`. No regressor defines the method, and
both existing call sites call it without a guard, `hyperopt.py:314` for tunable models and
`base.py:208` for the rest, so every regressor already raises `AttributeError` before a model
is built. That is a second, pre-existing breakage rather than a consequence of the refit
change; I bundled the two because I did not want to add another call to a contract that is
already partial, but they are separable and I will split them if you prefer.

Reproduction, on `da7e08d`, with `n_hyperopt_trials=2` and `MLPClassifier` on a three-class
target, every trial passes, and the refitted model then raises when it is trained:

```
Trial: 0
Trial: 1
Traceback (most recent call last):
  ...
  File "src/neuralk_foundry_ce/models/base.py", line 211, in _execute
    y_pred_all, mem_usage, time_usage = self._fit_predict_all(X, y, splits[0])
  ...
  File "src/neuralk_foundry_ce/models/classifier/mlp.py", line 83, in __init__
    layers.append(nn.Linear(prev, config['output_dim']))
KeyError: 'output_dim'
```

`CatBoostClassifier` fails the same way once the inputs declare a categorical feature:
`cat_features` comes from `get_fixed_params`, so the refit is handed a frame with a `category`
column and no `cat_features`:

```
CatBoostError: features data: pandas.DataFrame column 'cat' has dtype 'category' but is not in  cat_features list
```

Both complete on this branch. `LightGBMClassifier` never raised either way, but its refit was
losing `objective`, `metric`, `feature_pre_filter`, `verbose` and `min_gain_to_split=0.1`. That
last one is not cosmetic: on `make_classification(n_samples=1500, n_features=20, random_state=0)`,
with `n_estimators=60, num_leaves=15, max_depth=6, random_state=42` held fixed, `predict_proba`
moves by up to 1.280e-01 between `min_gain_to_split=0.1` and LightGBM's default of 0.0. So the
reported metrics were coming from a model the tuning never scored. After the change the
`LightGBMClassifier` refit config differs from the trials' only in `random_state`.

That residual is deliberate, and it is worth being precise about what it is. Anything written
into `get_model_params` as a plain literal rather than through `trial.suggest_*` is invisible to
Optuna, so no merge can bring it back: `random_state: trial._trial_id` in
`classifier/lightgbm.py`, `random_seed` in `classifier/catboost.py`, and, in the regressors, 
`objective`/`metric` at `regressor/lightgbm.py:57-58` and `loss_function`/`eval_metric` at
`regressor/catboost.py:57-58`. Fixing the seeds means choosing which trial's seed the final
model carries, which is a separate change and touches reproducibility of your reported numbers.
Moving the regressors' objective and metric into `get_fixed_params` would fix those as a side
effect of this merge, but which of the two homes you want them in is your call, so I have left
them where they are.

The `BaseModel.get_fixed_params` default returns `{}`, the narrow choice, enough to keep the
contract total. `LightGBMRegressor`, `XGBoostRegressor`, `CatBoostRegressor` and
`TabPFNRegressor` all raise `AttributeError` on that lookup, which both call sites perform
before any model is built, so none of them gets as far as a fit. The empty default unblocks the
lookup; it does not give them fixed params of their own.

Two tests in `tests/test_models.py`: one records the config `init_model` receives and asserts
the refit still carries the fixed keys, the other asserts the contract exists on the base class
and every regressor can answer it. Both fail on `main`.

Running `pytest tests` locally: 1 failed, 15 passed on `main` becomes 1 failed, 17 passed here.
`tests/test_step.py::test_step_registration_and_retrieval` already fails on `main` and is
untouched.

Happy to change the merge precedence, split the base-class default into its own PR, or close
this if you would rather fix it your own way.
